### PR TITLE
Remove sidenavbar tab opener

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
-import { Home, Shield, Settings, HelpCircle, Sparkles, PanelLeftClose, PanelLeftOpen, BarChart3, Plug, Edit3 } from 'lucide-react';
+import { Home, Shield, Settings, HelpCircle, Sparkles, BarChart3, Edit3 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { Input } from '@/components/ui/input';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Link, useLocation } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
@@ -37,7 +34,6 @@ const prefetchRoute = (path: string) => {
 		}
 	} catch {}
 };
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 interface SidebarProps {
 	isCollapsed: boolean;
 	onToggle: () => void;
@@ -54,7 +50,7 @@ interface NavSection {
 }
 export function Sidebar({
     isCollapsed,
-    onToggle,
+    onToggle: _onToggle,
     className
 }: SidebarProps) {
 	const location = useLocation();
@@ -126,15 +122,12 @@ export function Sidebar({
 		isCollapsed ? "w-16" : "w-56",
 		"bg-white text-gray-900 border-r border-gray-200",
 		className)}>
-			{/* Internal Header with Collapse Control */}
-			<div className={cn("border-b border-gray-200 flex items-center", isCollapsed ? "p-2 justify-between" : "p-3 justify-between") }>
+            {/* Internal Header */}
+            <div className={cn("border-b border-gray-200 flex items-center", isCollapsed ? "p-2 justify-start" : "p-3 justify-start") }>
 				<div className={cn("select-none", isCollapsed ? "text-base" : "text-xl")}
 					style={{ fontFamily: 'Montserrat, sans-serif' }}>
 					<span className="font-black text-black">{isCollapsed ? 'C' : 'Clario'}</span>
 				</div>
-				<Button onClick={onToggle} variant="outline" size="icon" className="h-8 w-8 rounded-md bg-transparent border border-gray-200 hover:bg-gray-100 text-gray-700">
-					{isCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
-				</Button>
 			</div>
 
 			<ScrollArea className="flex-1">


### PR DESCRIPTION
Remove the sidebar toggle button next to the logo and clean up related code.

The user requested to remove the "tab opener" element from the sidebar, which was the toggle button for collapsing/expanding the sidebar. This change removes the button, adjusts the header layout, and cleans up unused imports and props.

---
<a href="https://cursor.com/background-agent?bcId=bc-aecc599a-4357-4312-9b1f-a682ca3606d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aecc599a-4357-4312-9b1f-a682ca3606d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

